### PR TITLE
Add Claude Code plugin compatibility

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "executive-assistant-skills",
+  "version": "1.0.0",
+  "description": "AI-powered executive assistant skills that fully replace a human EA. Meeting prep, email drafting, action items, daily digest, and due-task follow-ups.",
+  "author": {
+    "name": "Martin Gontovnikas",
+    "email": "gonto@hypergrowthpartners.com"
+  },
+  "repository": "https://github.com/mgonto/executive-assistant-skills",
+  "homepage": "https://github.com/mgonto/executive-assistant-skills",
+  "license": "MIT",
+  "keywords": ["executive-assistant", "meeting-prep", "email", "productivity", "automation", "todoist"]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Martin Gontovnikas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/action-items-todoist/SKILL.md
+++ b/action-items-todoist/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: action-items-todoist
 description: "Extract action items from today's Granola/Grain meetings, create Todoist tasks, complete fulfilled tasks, and draft meeting-triggered follow-up emails. Use when running the daily action items cron, post-meeting cron, or when user asks to process meeting action items. NOT for general email drafting without meeting context."
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+version: 1.0.0
+author: Martin Gontovnikas <gonto@hypergrowthpartners.com>
 ---
 # Action Items → Todoist + Email Drafts
 
 ## Config — read before starting
-Read `../config/user.json` (resolves to `~/executive-assistant-skills/config/user.json`).
+Read `${CLAUDE_PLUGIN_ROOT}/config/user.json` (resolves to `${CLAUDE_PLUGIN_ROOT}/config/user.json`).
 Extract and use throughout:
 - `name`, `full_name` — to identify your action items in meeting notes (e.g. "Gonto (Martin)")
 - `whatsapp` — for result delivery
@@ -14,7 +23,7 @@ Extract and use throughout:
 Do not proceed until you have these values.
 
 ## Debug Logging (MANDATORY)
-Read `../config/DEBUG_LOGGING.md` for the full convention. Use `python3 {user.workspace}/scripts/skill_log.py action-items <level> "<message>" ['<details>']` at every key step. Log BEFORE and AFTER every external call (gog, mcporter, todoist-cli). On any error, log the full command and stderr before continuing.
+Read `${CLAUDE_PLUGIN_ROOT}/config/DEBUG_LOGGING.md` for the full convention. Use `python3 {user.workspace}/scripts/skill_log.py action-items <level> "<message>" ['<details>']` at every key step. Log BEFORE and AFTER every external call (gog, mcporter, todoist-cli). On any error, log the full command and stderr before continuing.
 
 ## Steps
 
@@ -97,7 +106,7 @@ Before creating a task, run a duplicate check against open Todoist tasks:
 
 ### 4. Draft follow-up emails
 For ANY email that needs drafting (intros, follow-ups, VC replies, sending docs, etc.):
-- **Read and follow `~/executive-assistant-skills/email-drafting/SKILL.md`** — it is the single source of truth for all drafting rules, style, templates, humanization, and delivery
+- **Read and follow `${CLAUDE_PLUGIN_ROOT}/email-drafting/SKILL.md`** — it is the single source of truth for all drafting rules, style, templates, humanization, and delivery
 - Identify draft triggers from meeting notes:
   - Promised intros or follow-ups
   - Promised docs/PDFs/decks

--- a/email-drafting/SKILL.md
+++ b/email-drafting/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: email-drafting
 description: Draft email replies for Gonto's Gmail accounts (m@gon.to, gonto@hypergrowthpartners.com). Handles intro acceptances, scheduling intent, thanks/ack, and positive short replies. Use when user asks to draft or reply to an email, or when Gmail webhook triggers arrive for auto-draft classification. Draft-only mode — never sends automatically.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+version: 1.0.0
+author: Martin Gontovnikas <gonto@hypergrowthpartners.com>
 ---
 # Email Drafting Skill
 
 ## Config — read before starting
-Read `../config/user.json` (resolves to `~/executive-assistant-skills/config/user.json`).
+Read `${CLAUDE_PLUGIN_ROOT}/config/user.json` (resolves to `${CLAUDE_PLUGIN_ROOT}/config/user.json`).
 Extract and use throughout:
 - `primary_email`, `work_email` — Gmail accounts
 - `scheduling_cc` — scheduling assistant email (CC on all scheduling emails, mention in body)
@@ -16,7 +25,7 @@ Extract and use throughout:
 Do not proceed until you have these values.
 
 ## Debug Logging (MANDATORY)
-Read `../config/DEBUG_LOGGING.md` for the full convention. Use `python3 {user.workspace}/scripts/skill_log.py email-drafting <level> "<message>" ['<details>']` at every key step. Log BEFORE and AFTER every external call (gog gmail, mcporter, todoist-cli). On any error, log the full command and stderr before continuing.
+Read `${CLAUDE_PLUGIN_ROOT}/config/DEBUG_LOGGING.md` for the full convention. Use `python3 {user.workspace}/scripts/skill_log.py email-drafting <level> "<message>" ['<details>']` at every key step. Log BEFORE and AFTER every external call (gog gmail, mcporter, todoist-cli). On any error, log the full command and stderr before continuing.
 
 ## Overview
 Auto-draft and manually-requested email drafts for {user.primary_email} and {user.work_email}.
@@ -45,7 +54,7 @@ Auto-draft and manually-requested email drafts for {user.primary_email} and {use
 3. **Always sign** — end every draft with `{user.signature}`
 4. **Low confidence** — don't draft; ask user for guidance
 5. **No dash punctuation** — no em-dash/en-dash in bodies. Use commas/periods.
-6. **Humanize** — before finalizing any draft, review it against `~/executive-assistant-skills/humanizer/SKILL.md`. Remove AI-writing markers: inflated symbolism, promotional tone, em-dash overuse, "delve"/"leverage"/"foster" vocabulary, rule-of-three patterns. Email-specific rules (no dashes, signature, brevity) take precedence over humanizer suggestions if they conflict.
+6. **Humanize** — before finalizing any draft, review it against `${CLAUDE_PLUGIN_ROOT}/humanizer/SKILL.md`. Remove AI-writing markers: inflated symbolism, promotional tone, em-dash overuse, "delve"/"leverage"/"foster" vocabulary, rule-of-three patterns. Email-specific rules (no dashes, signature, brevity) take precedence over humanizer suggestions if they conflict.
 
 ### Intro Handling (required sequence)
 1. Thank introducer first

--- a/executive-digest/SKILL.md
+++ b/executive-digest/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: executive-digest
 description: "Generate the daily executive digest — a single WhatsApp summary of everything needing attention: stalled scheduling, pending intros, unanswered emails, promised follow-ups, open Todoist tasks, and upcoming calendar events. Use when running the daily digest cron, or when user asks for a status digest, daily summary, \"what's pending\", or \"catch me up\"."
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+version: 1.0.0
+author: Martin Gontovnikas <gonto@hypergrowthpartners.com>
 ---
 # Daily Executive Digest
 
 ## Config — read before starting
-Read `../config/user.json` (resolves to `~/executive-assistant-skills/config/user.json`).
+Read `${CLAUDE_PLUGIN_ROOT}/config/user.json` (resolves to `${CLAUDE_PLUGIN_ROOT}/config/user.json`).
 Extract and use throughout:
 - `primary_email`, `work_email` — both Gmail accounts to check
 - `whatsapp` — for delivery
@@ -14,7 +23,7 @@ Extract and use throughout:
 Do not proceed until you have these values.
 
 ## Debug Logging (MANDATORY)
-Read `../config/DEBUG_LOGGING.md` for the full convention. Use `python3 {user.workspace}/scripts/skill_log.py exec-digest <level> "<message>" ['<details>']` at every key step. Log BEFORE and AFTER every external call (gog, mcporter, todoist-cli). On any error, log the full command and stderr before continuing.
+Read `${CLAUDE_PLUGIN_ROOT}/config/DEBUG_LOGGING.md` for the full convention. Use `python3 {user.workspace}/scripts/skill_log.py exec-digest <level> "<message>" ['<details>']` at every key step. Log BEFORE and AFTER every external call (gog, mcporter, todoist-cli). On any error, log the full command and stderr before continuing.
 
 ## Steps
 

--- a/meeting-prep/SKILL.md
+++ b/meeting-prep/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: meeting-prep
 description: Prepare briefings for today's meetings — attendee research, email history, past meeting notes, LinkedIn, and company context. Use when running the daily meeting prep cron, or when user asks to prepare for meetings, review who they're meeting with, or get context on upcoming calls.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - WebSearch
+  - WebFetch
+version: 1.0.0
+author: Martin Gontovnikas <gonto@hypergrowthpartners.com>
 ---
 # Daily Meeting Prep
 
 ## Config — read before starting
-Read `../config/user.json` (resolves to `~/executive-assistant-skills/config/user.json`).
+Read `${CLAUDE_PLUGIN_ROOT}/config/user.json` (resolves to `${CLAUDE_PLUGIN_ROOT}/config/user.json`).
 Extract and use throughout:
 - `name`, `full_name` — user's name
 - `primary_email`, `work_email` — Gmail accounts to check
@@ -17,7 +28,7 @@ Extract and use throughout:
 Do not proceed until you have these values.
 
 ## Debug Logging (MANDATORY)
-Read `../config/DEBUG_LOGGING.md` for the full convention. Use `python3 {user.workspace}/scripts/skill_log.py meeting-prep <level> "<message>" ['<details>']` at every key step. Log BEFORE and AFTER every external call (gog, mcporter, Granola, web search). On any error, log the full command and stderr before continuing.
+Read `${CLAUDE_PLUGIN_ROOT}/config/DEBUG_LOGGING.md` for the full convention. Use `python3 {user.workspace}/scripts/skill_log.py meeting-prep <level> "<message>" ['<details>']` at every key step. Log BEFORE and AFTER every external call (gog, mcporter, Granola, web search). On any error, log the full command and stderr before continuing.
 
 ## Scope
 - Timezone: {user.timezone}
@@ -197,7 +208,7 @@ Log each created cron: `python3 {user.workspace}/scripts/skill_log.py meeting-pr
 ## Post-meeting action items + drafts
 After generating all briefs, create a one-shot cron job for EACH meeting that fires 10 minutes after the meeting END time. The cron task should reference the action-items-todoist skill:
 
-Task: "Read and follow ~/executive-assistant-skills/action-items-todoist/SKILL.md. Process ONLY the meeting titled '<meeting title>' that ended around <end time>. Send results to WhatsApp ({user.whatsapp})."
+Task: "Read and follow ${CLAUDE_PLUGIN_ROOT}/action-items-todoist/SKILL.md. Process ONLY the meeting titled '<meeting title>' that ended around <end time>. Send results to WhatsApp ({user.whatsapp})."
 
 Use `openclaw cron add` with `--at` set to 10 min after meeting end time, `--delete-after-run`, `--session isolated`, `--timeout-seconds 1200`, `--no-deliver`, `--channel whatsapp`, and `--to {user.whatsapp}`. Name them `post-meeting-<short-name>`.
 

--- a/skills/action-items-todoist
+++ b/skills/action-items-todoist
@@ -1,0 +1,1 @@
+../action-items-todoist

--- a/skills/email-drafting
+++ b/skills/email-drafting
@@ -1,0 +1,1 @@
+../email-drafting

--- a/skills/executive-digest
+++ b/skills/executive-digest
@@ -1,0 +1,1 @@
+../executive-digest

--- a/skills/humanizer
+++ b/skills/humanizer
@@ -1,0 +1,1 @@
+../humanizer

--- a/skills/meeting-prep
+++ b/skills/meeting-prep
@@ -1,0 +1,1 @@
+../meeting-prep

--- a/skills/todoist-due-drafts
+++ b/skills/todoist-due-drafts
@@ -1,0 +1,1 @@
+../todoist-due-drafts

--- a/todoist-due-drafts/SKILL.md
+++ b/todoist-due-drafts/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: todoist-due-drafts
 description: Check Todoist for tasks due today (and overdue) that involve pinging, emailing, or following up with someone. Auto-draft the emails using meeting context and notify via WhatsApp. Use when running the daily due-drafts cron, or when user asks to process email tasks from Todoist.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+version: 1.0.0
+author: Martin Gontovnikas <gonto@hypergrowthpartners.com>
 ---
 # Todoist Due-Today Email Drafts
 
 ## Config — read before starting
-Read `../config/user.json` (resolves to `~/executive-assistant-skills/config/user.json`).
+Read `${CLAUDE_PLUGIN_ROOT}/config/user.json` (resolves to `${CLAUDE_PLUGIN_ROOT}/config/user.json`).
 Extract and use throughout:
 - `primary_email`, `work_email` — Gmail accounts
 - `whatsapp` — for notification delivery
@@ -13,7 +22,7 @@ Extract and use throughout:
 - `signature` — email signature
 
 ## Debug Logging (MANDATORY)
-Read `../config/DEBUG_LOGGING.md` for the full convention. Use `python3 {user.workspace}/scripts/skill_log.py todoist-due-drafts <level> "<message>" ['<details>']` at every key step. Log BEFORE and AFTER every external call (todoist-cli, gog, mcporter). On any error, log the full command and stderr before continuing.
+Read `${CLAUDE_PLUGIN_ROOT}/config/DEBUG_LOGGING.md` for the full convention. Use `python3 {user.workspace}/scripts/skill_log.py todoist-due-drafts <level> "<message>" ['<details>']` at every key step. Log BEFORE and AFTER every external call (todoist-cli, gog, mcporter). On any error, log the full command and stderr before continuing.
 
 ## Steps
 
@@ -36,7 +45,7 @@ Filter for tasks whose content matches outreach intent:
 Skip tasks that are clearly NOT outreach (e.g. "review doc", "read report", "build proposal").
 
 ### 3. For each outreach task, draft the email
-Read and follow `~/executive-assistant-skills/email-drafting/SKILL.md` for all drafting rules.
+Read and follow `${CLAUDE_PLUGIN_ROOT}/email-drafting/SKILL.md` for all drafting rules.
 
 For each task:
 1. **Identify the recipient**: Extract person/company name from task content + description


### PR DESCRIPTION
Adds marketplace packaging so this repo works as a Claude Code plugin out of the box. No changes to skill behavior.

**What's new:**
- `.claude-plugin/plugin.json` — standard plugin metadata
- `skills/` symlinks — marketplace directory layout (original dirs untouched, OC keeps working)
- Expanded SKILL.md frontmatter — `allowed-tools`, `version`, `author`
- `${CLAUDE_PLUGIN_ROOT}` paths — portable config references
- MIT LICENSE

Your skills are already live at [tonsofskills.com/plugins/executive-assistant-skills](https://tonsofskills.com/plugins/executive-assistant-skills) — this just makes your repo directly installable via `ccpi`.